### PR TITLE
Fix code scanning alert no. 20: Disabling certificate validation

### DIFF
--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -1178,7 +1178,7 @@ describe('supports http with nodejs', function () {
           port: parsed.port,
           path: parsed.path,
           protocol: parsed.protocol,
-          rejectUnauthorized: false
+          rejectUnauthorized: true
         };
 
         http.get(opts, function (res) {


### PR DESCRIPTION
Fixes [https://github.com/Rose2161/axios/security/code-scanning/20](https://github.com/Rose2161/axios/security/code-scanning/20)

To fix the problem, we should ensure that the `rejectUnauthorized` option is set to `true` or removed entirely to use the default value. This change will maintain the security of the HTTPS connection by validating certificates. We will update the `opts` object in the test to ensure that certificate validation is not disabled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
